### PR TITLE
Update ValueDetails parsing

### DIFF
--- a/src/main/java/com/opentext/idol/types/responses/ValueDetails.java
+++ b/src/main/java/com/opentext/idol/types/responses/ValueDetails.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2026 Open Text.
+ *
+ * Licensed under the MIT License (the "License"); you may not use this file
+ * except in compliance with the License.
+ *
+ * The only warranties for products and services of Open Text and its affiliates
+ * and licensors ("Open Text") are as may be set forth in the express warranty
+ * statements accompanying such products and services. Nothing herein should be
+ * construed as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained herein. The
+ * information contained herein is subject to change without notice.
+ */
+
+package com.opentext.idol.types.responses;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import com.opentext.idol.types.xjc.DoubleAdapter;
+import com.opentext.idol.types.xjc.LongAdapter;
+
+
+/**
+ * <p>Java class for valueDetails complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="valueDetails"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="values" type="{http://www.w3.org/2001/XMLSchema}integer"/&gt;
+ *         &lt;choice&gt;
+ *           &lt;element name="value_sum" type="{http://www.w3.org/2001/XMLSchema}double"/&gt;
+ *           &lt;element name="valuesum" type="{http://www.w3.org/2001/XMLSchema}double"/&gt;
+ *         &lt;/choice&gt;
+ *         &lt;choice&gt;
+ *           &lt;element name="value_average" type="{http://schemas.autonomy.com/aci/}dateOrNumber"/&gt;
+ *           &lt;element name="valueaverage" type="{http://schemas.autonomy.com/aci/}dateOrNumber"/&gt;
+ *         &lt;/choice&gt;
+ *         &lt;choice&gt;
+ *           &lt;element name="value_min" type="{http://schemas.autonomy.com/aci/}dateOrNumber"/&gt;
+ *           &lt;element name="valuemin" type="{http://schemas.autonomy.com/aci/}dateOrNumber"/&gt;
+ *         &lt;/choice&gt;
+ *         &lt;choice&gt;
+ *           &lt;element name="value_max" type="{http://schemas.autonomy.com/aci/}dateOrNumber"/&gt;
+ *           &lt;element name="valuemax" type="{http://schemas.autonomy.com/aci/}dateOrNumber"/&gt;
+ *         &lt;/choice&gt;
+ *         &lt;element name="valuepercentile" type="{http://schemas.autonomy.com/aci/}dateOrNumberPercentile" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "valueDetails", propOrder = {
+    "values",
+    "valueSum",
+    "valuesum",
+    "valueAverage",
+    "valueaverage",
+    "valueMin",
+    "valuemin",
+    "valueMax",
+    "valuemax",
+    "valuepercentile"
+})
+public class ValueDetails
+    implements Serializable
+{
+
+    @XmlElement(required = true, type = String.class)
+    @XmlJavaTypeAdapter(LongAdapter.class)
+    @XmlSchemaType(name = "integer")
+    protected Long values;
+    @XmlElement(name = "value_sum")
+    @XmlJavaTypeAdapter(DoubleAdapter.class)
+    protected Double valueSum;
+    protected Double valuesum;
+    @XmlElement(name = "value_average")
+    protected DateOrNumber valueAverage;
+    protected DateOrNumber valueaverage;
+    @XmlElement(name = "value_min")
+    protected DateOrNumber valueMin;
+    protected DateOrNumber valuemin;
+    @XmlElement(name = "value_max")
+    protected DateOrNumber valueMax;
+    protected DateOrNumber valuemax;
+    protected List<DateOrNumberPercentile> valuepercentile;
+
+    /**
+     * Gets the value of the values property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public Long getValues() {
+        return values;
+    }
+
+    /**
+     * Sets the value of the values property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValues(Long value) {
+        this.values = value;
+    }
+
+    /**
+     * Gets the value of the valueSum property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Double }
+     *     
+     */
+    public Double getValueSum() {
+        return valueSum != null ? valueSum : valuesum;
+    }
+
+    /**
+     * Sets the value of the valueSum property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Double }
+     *     
+     */
+    public void setValueSum(Double value) {
+        this.valueSum = value;
+        this.valuesum = value;
+    }
+
+    /**
+     * Gets the value of the valuesum property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Double }
+     *     
+     */
+    public Double getValuesum() {
+        return getValueSum();
+    }
+
+    /**
+     * Sets the value of the valuesum property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Double }
+     *     
+     */
+    public void setValuesum(Double value) {
+        setValueSum(value);
+    }
+
+    /**
+     * Gets the value of the valueAverage property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public DateOrNumber getValueAverage() {
+        return valueAverage != null ? valueAverage : valueaverage;
+    }
+
+    /**
+     * Sets the value of the valueAverage property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public void setValueAverage(DateOrNumber value) {
+        this.valueAverage = value;
+        this.valueaverage = value;
+    }
+
+    /**
+     * Gets the value of the valueaverage property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public DateOrNumber getValueaverage() {
+        return getValueAverage();
+    }
+
+    /**
+     * Sets the value of the valueaverage property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public void setValueaverage(DateOrNumber value) {
+        setValueAverage(value);
+    }
+
+    /**
+     * Gets the value of the valueMin property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public DateOrNumber getValueMin() {
+        return valueMin != null ? valueMin : valuemin;
+    }
+
+    /**
+     * Sets the value of the valueMin property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public void setValueMin(DateOrNumber value) {
+        this.valueMin = value;
+        this.valuemin = value;
+    }
+
+    /**
+     * Gets the value of the valuemin property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public DateOrNumber getValuemin() {
+        return getValueMin();
+    }
+
+    /**
+     * Sets the value of the valuemin property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public void setValuemin(DateOrNumber value) {
+        setValueMin(value);
+    }
+
+    /**
+     * Gets the value of the valueMax property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public DateOrNumber getValueMax() {
+        return valueMax != null ? valueMax : valuemax;
+    }
+
+    /**
+     * Sets the value of the valueMax property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public void setValueMax(DateOrNumber value) {
+        this.valueMax = value;
+        this.valuemax = value;
+    }
+
+    /**
+     * Gets the value of the valuemax property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public DateOrNumber getValuemax() {
+        return getValueMax();
+    }
+
+    /**
+     * Sets the value of the valuemax property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateOrNumber }
+     *     
+     */
+    public void setValuemax(DateOrNumber value) {
+        setValueMax(value);
+    }
+
+    /**
+     * Gets the value of the valuepercentile property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the Jakarta XML Binding object.
+     * This is why there is not a <CODE>set</CODE> method for the valuepercentile property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getValuepercentile().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link DateOrNumberPercentile }
+     * 
+     * 
+     */
+    public List<DateOrNumberPercentile> getValuepercentile() {
+        if (valuepercentile == null) {
+            valuepercentile = new ArrayList<DateOrNumberPercentile>();
+        }
+        return this.valuepercentile;
+    }
+
+}

--- a/src/main/java/com/opentext/idol/types/xjc/DoubleAdapter.java
+++ b/src/main/java/com/opentext/idol/types/xjc/DoubleAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Open Text.
+ *
+ * Licensed under the MIT License (the "License"); you may not use this file
+ * except in compliance with the License.
+ *
+ * The only warranties for products and services of Open Text and its affiliates
+ * and licensors ("Open Text") are as may be set forth in the express warranty
+ * statements accompanying such products and services. Nothing herein should be
+ * construed as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained herein. The
+ * information contained herein is subject to change without notice.
+ */
+
+package com.opentext.idol.types.xjc;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+public class DoubleAdapter extends XmlAdapter<String, Double> {
+    private static final DecimalFormat DECIMAL_FORMAT;
+    
+    static {
+        DECIMAL_FORMAT = new DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.US));
+        DECIMAL_FORMAT.setMaximumFractionDigits(2);
+        DECIMAL_FORMAT.setMinimumFractionDigits(2);
+        DECIMAL_FORMAT.setGroupingUsed(false);
+    }
+
+    public static Double parseDouble(final String s) {
+        if (s == null || s.isEmpty()) {
+            return null;
+        }
+        return Double.valueOf(s);
+    }
+    
+    public static String printDouble(final Double d) {
+        if (d == null) {
+            return null;
+        }
+        return DECIMAL_FORMAT.format(d);
+    }
+
+    @Override
+    public Double unmarshal(final String v) { 
+        return parseDouble(v);
+    }
+
+    @Override
+    public String marshal(final Double v) {
+        return printDouble(v);
+    }
+}

--- a/src/main/java/com/opentext/idol/types/xjc/LongAdapter.java
+++ b/src/main/java/com/opentext/idol/types/xjc/LongAdapter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Open Text.
+ *
+ * Licensed under the MIT License (the "License"); you may not use this file
+ * except in compliance with the License.
+ *
+ * The only warranties for products and services of Open Text and its affiliates
+ * and licensors ("Open Text") are as may be set forth in the express warranty
+ * statements accompanying such products and services. Nothing herein should be
+ * construed as constituting an additional warranty. Open Text shall not be
+ * liable for technical or editorial errors or omissions contained herein. The
+ * information contained herein is subject to change without notice.
+ */
+
+
+package com.opentext.idol.types.xjc;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+public class LongAdapter
+    extends XmlAdapter<String, Long>
+{
+    public Long unmarshal(String value) {
+        return new Long(value);
+    }
+
+    public String marshal(Long value) {
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
+    }
+
+}

--- a/src/main/xjb/responses/bindings.xjb
+++ b/src/main/xjb/responses/bindings.xjb
@@ -167,6 +167,9 @@
             <annox:annotate target="class">@lombok.EqualsAndHashCode</annox:annotate>
             <annox:annotate target="class">@lombok.ToString</annox:annotate>
         </jaxb:bindings>
+        <jaxb:bindings node="//xs:complexType[@name='valueDetails']">
+            <jaxb:class ref="com.opentext.idol.types.responses.ValueDetails"/>
+        </jaxb:bindings>
     </jaxb:bindings>
     <jaxb:bindings schemaLocation="../../xsds/responses/getSampleResponse.xsd">
         <jaxb:bindings node="xs:complexType[@name='getSampleResponseData']">

--- a/src/main/xjb/responses/bindings.xjb
+++ b/src/main/xjb/responses/bindings.xjb
@@ -168,6 +168,7 @@
             <annox:annotate target="class">@lombok.ToString</annox:annotate>
         </jaxb:bindings>
         <jaxb:bindings node="//xs:complexType[@name='valueDetails']">
+            <!-- use this instead of a generated class so we can support multiple field naming schemes, for backwards compatibility -->
             <jaxb:class ref="com.opentext.idol.types.responses.ValueDetails"/>
         </jaxb:bindings>
     </jaxb:bindings>

--- a/src/main/xsds/responses/getQueryTagValuesResponse.xsd
+++ b/src/main/xsds/responses/getQueryTagValuesResponse.xsd
@@ -56,11 +56,23 @@
     <xs:complexType name="valueDetails">
         <xs:sequence>
             <xs:element name="values" type="xs:integer"/>
-            <xs:element name="value_sum" type="xs:double"/>
-            <xs:element name="value_average" type="autn:dateOrNumber"/>
-            <xs:element name="value_min" type="autn:dateOrNumber"/>
-            <xs:element name="value_max" type="autn:dateOrNumber"/>
-            <xs:element name="value_percentile" type="autn:dateOrNumberPercentile" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:choice>
+                <xs:element name="value_sum" type="xs:double"/>
+                <xs:element name="valuesum" type="xs:double"/>
+            </xs:choice>
+            <xs:choice>
+                <xs:element name="value_average" type="autn:dateOrNumber"/>
+                <xs:element name="valueaverage" type="autn:dateOrNumber"/>
+            </xs:choice>
+            <xs:choice>
+                <xs:element name="value_min" type="autn:dateOrNumber"/>
+                <xs:element name="valuemin" type="autn:dateOrNumber"/>
+            </xs:choice>
+            <xs:choice>
+                <xs:element name="value_max" type="autn:dateOrNumber"/>
+                <xs:element name="valuemax" type="autn:dateOrNumber"/>
+            </xs:choice>
+            <xs:element name="valuepercentile" type="autn:dateOrNumberPercentile" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -75,6 +87,7 @@
         <xs:attribute name="end_date" type="xs:string"/>
         <xs:attribute name="end_date_with_offset" type="xs:string"/>
         <xs:attribute name="value" type="xs:string"/>
+        <xs:attribute name="type" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="values">
@@ -116,4 +129,3 @@
         </xs:simpleContent>
     </xs:complexType>
 </xs:schema>
-

--- a/src/test/java/com/opentext/idol/types/ResponseParsingTest.java
+++ b/src/test/java/com/opentext/idol/types/ResponseParsingTest.java
@@ -87,18 +87,16 @@ public class ResponseParsingTest extends AbstractParsingTest<Object> {
     }
 
     @Test
-    protected void ValueDetailsCompatibilityTest(){
+    protected void ValueDetailsCompatibilityTest() throws IOException {
         TestData<GetQueryTagValuesResponseData> data = new TestData<>(GetQueryTagValuesResponseData.class, "/getQueryTagValuesFieldDependenceMultiLevelResponse-compat.xml");
         final Processor<GetQueryTagValuesResponseData> processor = getProcessor(processorFactory, data);
         try (final MockAciResponseInputStream mockInputStream = new MockAciResponseInputStream(
-            this.getClass().getResourceAsStream("/getQueryTagValuesFieldDependenceMultiLevelResponse-compat.xml")
-            )) {
+            getClass().getResourceAsStream("/getQueryTagValuesFieldDependenceMultiLevelResponse-compat.xml")
+        )) {
             final GetQueryTagValuesResponseData gqtv = processor.process(mockInputStream);
             assertNotNull(gqtv);
-            assertEquals(gqtv.getValues().getField().get(0).getField().get(0).getValueDetails().getValueMin().getValue(), 1.78);
-            assertEquals(gqtv.getValues().getField().get(0).getField().get(0).getValueDetails().getValuemin().getValue(), 1.78);
-        } catch (final IOException e) {
-            throw new RuntimeException(e);
+            assertEquals(1.78, gqtv.getValues().getField().get(0).getField().get(0).getValueDetails().getValueMin().getValue());
+            assertEquals(1.78, gqtv.getValues().getField().get(0).getField().get(0).getValueDetails().getValuemin().getValue());
         }
     }
 }

--- a/src/test/java/com/opentext/idol/types/ResponseParsingTest.java
+++ b/src/test/java/com/opentext/idol/types/ResponseParsingTest.java
@@ -15,12 +15,19 @@
 package com.opentext.idol.types;
 
 import com.autonomy.aci.client.services.Processor;
+
 import com.opentext.idol.types.marshalling.ProcessorFactory;
 import com.opentext.idol.types.marshalling.marshallers.MarshallerFactory;
 import com.opentext.idol.types.marshalling.marshallers.ResponseParser;
 import com.opentext.idol.types.responses.*;
 
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ResponseParsingTest extends AbstractParsingTest<Object> {
 
@@ -38,6 +45,7 @@ public class ResponseParsingTest extends AbstractParsingTest<Object> {
                 new TestData<>(GetContentResponseData.class, "/getContent.xml"),
                 new TestData<>(GetQueryTagValuesResponseData.class, "/getQueryTagValuesRangeResponse.xml"),
                 new TestData<>(GetQueryTagValuesResponseData.class, "/getQueryTagValuesDateRangeResponse.xml"),
+                new TestData<>(GetQueryTagValuesResponseData.class, "/getQueryTagValuesFieldDependenceMultiLevelResponse.xml"),
 //                new TestData<>(GetSampleResponseData.class, ""),
                 new TestData<>(GetStatusResponseData.class, "/getStatus.xml"),
                 new TestData<>(GetTagNamesResponseData.class, "/getTagNames.xml"),
@@ -76,5 +84,21 @@ public class ResponseParsingTest extends AbstractParsingTest<Object> {
     @Override
     protected <T extends Object> ResponseParser getResponseParser(final MarshallerFactory marshallerFactory, final TestData<T> data) {
         return marshallerFactory.getResponseDataParser(data.getType());
+    }
+
+    @Test
+    protected void ValueDetailsCompatibilityTest(){
+        TestData<GetQueryTagValuesResponseData> data = new TestData<>(GetQueryTagValuesResponseData.class, "/getQueryTagValuesFieldDependenceMultiLevelResponse-compat.xml");
+        final Processor<GetQueryTagValuesResponseData> processor = getProcessor(processorFactory, data);
+        try (final MockAciResponseInputStream mockInputStream = new MockAciResponseInputStream(
+            this.getClass().getResourceAsStream("/getQueryTagValuesFieldDependenceMultiLevelResponse-compat.xml")
+            )) {
+            final GetQueryTagValuesResponseData gqtv = processor.process(mockInputStream);
+            assertNotNull(gqtv);
+            assertEquals(gqtv.getValues().getField().get(0).getField().get(0).getValueDetails().getValueMin().getValue(), 1.78);
+            assertEquals(gqtv.getValues().getField().get(0).getField().get(0).getValueDetails().getValuemin().getValue(), 1.78);
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/resources/getQueryTagValuesFieldDependenceMultiLevelResponse-compat.xml
+++ b/src/test/resources/getQueryTagValuesFieldDependenceMultiLevelResponse-compat.xml
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<autnresponse xmlns:autn="http://schemas.autonomy.com/aci/">
+  <action>GETQUERYTAGVALUES</action>
+  <response>SUCCESS</response>
+  <responsedata>
+    <autn:number_of_fields>3</autn:number_of_fields>
+    <autn:field>
+      <autn:name>DOCUMENT/PRFIELD1</autn:name>
+      <autn:name>DOCUMENT/PET</autn:name>
+      <autn:name>DOCUMENT/PRFIELD2</autn:name>
+    </autn:field>
+    <autn:values>
+      <autn:field value="0,1e+5" type="range" count="1102">
+        <autn:field value="CAT" count="290">
+          <autn:value_details>
+            <autn:values>290</autn:values>
+            <autn:valuesum>15157447.30</autn:valuesum>
+            <autn:valueaverate>52267.06</autn:valueaverate>
+            <autn:valuemin>1.78</autn:valuemin>
+            <autn:valuemax>986595.15</autn:valuemax>
+            <autn:valuepercentile percentile="10">24925.21</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">55391.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">94480.02</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">130150.21</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">156221.18</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="271">
+          <autn:value_details>
+            <autn:values>271</autn:values>
+            <autn:valuesum>17421265.70</autn:valuesum>
+            <autn:valueaverate>64285.11</autn:valueaverate>
+            <autn:valuemin>4.24</autn:valuemin>
+            <autn:valuemax>993074.96</autn:valuemax>
+            <autn:valuepercentile percentile="10">26703.93</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">54868.39</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">103851.41</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">162844.03</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">198110.22</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="266">
+          <autn:value_details>
+            <autn:values>266</autn:values>
+            <autn:valuesum>10661085.53</autn:valuesum>
+            <autn:valueaverate>40079.27</autn:valueaverate>
+            <autn:valuemin>1.09</autn:valuemin>
+            <autn:valuemax>994009.15</autn:valuemax>
+            <autn:valuepercentile percentile="10">13993.89</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">30479.51</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">67142.07</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">114100.82</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">149891.65</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="275">
+          <autn:value_details>
+            <autn:values>275</autn:values>
+            <autn:valuesum>10815786.33</autn:valuesum>
+            <autn:valueaverate>39330.13</autn:valueaverate>
+            <autn:valuemin>5.84</autn:valuemin>
+            <autn:valuemax>962168.64</autn:valuemax>
+            <autn:valuepercentile percentile="10">21497.91</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">43271.01</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">75765.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">120212.92</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">144003.46</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="1e+5,2e+5" type="range" count="121">
+        <autn:field value="CAT" count="27">
+          <autn:value_details>
+            <autn:values>27</autn:values>
+            <autn:valuesum>12914500.57</autn:valuesum>
+            <autn:valueaverate>478314.84</autn:valueaverate>
+            <autn:valuemin>27760.23</autn:valuemin>
+            <autn:valuemax>952893.61</autn:valuemax>
+            <autn:valuepercentile percentile="10">96947.85</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">168644.01</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">485768.05</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">758187.16</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">892292.61</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:valuesum>11131200.08</autn:valuesum>
+            <autn:valueaverate>428123.08</autn:valueaverate>
+            <autn:valuemin>21403.14</autn:valuemin>
+            <autn:valuemax>916414.7</autn:valuemax>
+            <autn:valuepercentile percentile="10">41951.95</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">245419.76</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">396824.41</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">628484.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">871320.45</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="31">
+          <autn:value_details>
+            <autn:values>31</autn:values>
+            <autn:valuesum>15964484.77</autn:valuesum>
+            <autn:valueaverate>514983.38</autn:valueaverate>
+            <autn:valuemin>32361.59</autn:valuemin>
+            <autn:valuemax>972633.87</autn:valuemax>
+            <autn:valuepercentile percentile="10">100303.96</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">182650.71</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">522854.27</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">785529.41</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">931478.96</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="37">
+          <autn:value_details>
+            <autn:values>37</autn:values>
+            <autn:valuesum>23828900.09</autn:valuesum>
+            <autn:valueaverate>644024.33</autn:valueaverate>
+            <autn:valuemin>100928.78</autn:valuemin>
+            <autn:valuemax>999435.61</autn:valuemax>
+            <autn:valuepercentile percentile="10">183039.23</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">473874.88</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">738429.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">846788.91</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">949961.97</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="2e+5,3e+5" type="range" count="82">
+        <autn:field value="CAT" count="21">
+          <autn:value_details>
+            <autn:values>21</autn:values>
+            <autn:valuesum>10355440.17</autn:valuesum>
+            <autn:valueaverate>493116.21</autn:valueaverate>
+            <autn:valuemin>71904.72</autn:valuemin>
+            <autn:valuemax>985728.53</autn:valuemax>
+            <autn:valuepercentile percentile="10">182406.12</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">327229.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">417793.46</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">621053.43</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">940898.15</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="15">
+          <autn:value_details>
+            <autn:values>15</autn:values>
+            <autn:valuesum>5726845.69</autn:valuesum>
+            <autn:valueaverate>381789.71</autn:valueaverate>
+            <autn:valuemin>17862.39</autn:valuemin>
+            <autn:valuemax>848123.44</autn:valuemax>
+            <autn:valuepercentile percentile="10">48297.53</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">90678.82</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">347059.09</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">610836.84</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">816736.01</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="24">
+          <autn:value_details>
+            <autn:values>24</autn:values>
+            <autn:valuesum>10598218.56</autn:valuesum>
+            <autn:valueaverate>441592.44</autn:valueaverate>
+            <autn:valuemin>3360.82</autn:valuemin>
+            <autn:valuemax>959114.81</autn:valuemax>
+            <autn:valuepercentile percentile="10">43928.39</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">53428.43</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">451572.08</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">615189.18</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">933396.07</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="22">
+          <autn:value_details>
+            <autn:values>22</autn:values>
+            <autn:valuesum>12681844.24</autn:valuesum>
+            <autn:valueaverate>576447.47</autn:valueaverate>
+            <autn:valuemin>12380.12</autn:valuemin>
+            <autn:valuemax>977385.83</autn:valuemax>
+            <autn:valuepercentile percentile="10">168907.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">375303.97</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">591551.92</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">779934.76</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">935445.46</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="3e+5,4e+5" type="range" count="99">
+        <autn:field value="CAT" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:valuesum>12905427.78</autn:valuesum>
+            <autn:valueaverate>496362.61</autn:valueaverate>
+            <autn:valuemin>21762.61</autn:valuemin>
+            <autn:valuemax>988473.93</autn:valuemax>
+            <autn:valuepercentile percentile="10">123967.34</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">296510.87</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">458297.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">682620.14</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">906208.35</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="25">
+          <autn:value_details>
+            <autn:values>25</autn:values>
+            <autn:valuesum>12145665.57</autn:valuesum>
+            <autn:valueaverate>485826.62</autn:valueaverate>
+            <autn:valuemin>59584.15</autn:valuemin>
+            <autn:valuemax>954265.69</autn:valuemax>
+            <autn:valuepercentile percentile="10">142859.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">290900.87</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">473607.95</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">650082.08</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">940586.34</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="23">
+          <autn:value_details>
+            <autn:values>23</autn:values>
+            <autn:valuesum>11780720.50</autn:valuesum>
+            <autn:valueaverate>512205.24</autn:valueaverate>
+            <autn:valuemin>2794.41</autn:valuemin>
+            <autn:valuemax>976535.01</autn:valuemax>
+            <autn:valuepercentile percentile="10">106327.41</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">341133.51</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">471927.36</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">801728.64</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">903995.93</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="25">
+          <autn:value_details>
+            <autn:values>25</autn:values>
+            <autn:valuesum>13944669.29</autn:valuesum>
+            <autn:valueaverate>557786.77</autn:valueaverate>
+            <autn:valuemin>31993.67</autn:valuemin>
+            <autn:valuemax>954235.22</autn:valuemax>
+            <autn:valuepercentile percentile="10">255054.08</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">338133.18</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">620974.21</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">732722.49</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">915464.73</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="4e+5,5e+5" type="range" count="96">
+        <autn:field value="CAT" count="24">
+          <autn:value_details>
+            <autn:values>24</autn:values>
+            <autn:valuesum>9389638.44</autn:valuesum>
+            <autn:valueaverate>391234.93</autn:valueaverate>
+            <autn:valuemin>7778.88</autn:valuemin>
+            <autn:valuemax>964179.01</autn:valuemax>
+            <autn:valuepercentile percentile="10">60313.32</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">126145.57</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">287628.96</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">576440.02</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">769155.49</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="20">
+          <autn:value_details>
+            <autn:values>20</autn:values>
+            <autn:valuesum>10979013.24</autn:valuesum>
+            <autn:valueaverate>548950.66</autn:valueaverate>
+            <autn:valuemin>8057.18</autn:valuemin>
+            <autn:valuemax>963585.23</autn:valuemax>
+            <autn:valuepercentile percentile="10">74917.75</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">220605.58</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">538020.91</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">836265.98</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">908026.89</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="22">
+          <autn:value_details>
+            <autn:values>22</autn:values>
+            <autn:valuesum>9976724.22</autn:valuesum>
+            <autn:valueaverate>453487.46</autn:valueaverate>
+            <autn:valuemin>999.12</autn:valuemin>
+            <autn:valuemax>871979.87</autn:valuemax>
+            <autn:valuepercentile percentile="10">67741.54</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">264598.27</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">427789.18</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">656715.06</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">807782.35</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="30">
+          <autn:value_details>
+            <autn:values>30</autn:values>
+            <autn:valuesum>14673574.22</autn:valuesum>
+            <autn:valueaverate>489119.14</autn:valueaverate>
+            <autn:valuemin>15105.01</autn:valuemin>
+            <autn:valuemax>973162.81</autn:valuemax>
+            <autn:valuepercentile percentile="10">66019.25</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">222458.01</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">475668.89</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">732428.09</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">937055.34</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="5e+5,6e+5" type="range" count="94">
+        <autn:field value="CAT" count="25">
+          <autn:value_details>
+            <autn:values>25</autn:values>
+            <autn:valuesum>11339400.49</autn:valuesum>
+            <autn:valueaverate>453576.02</autn:valueaverate>
+            <autn:valuemin>14703.35</autn:valuemin>
+            <autn:valuemax>935905.01</autn:valuemax>
+            <autn:valuepercentile percentile="10">42205.39</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">109677.76</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">454038.06</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">710463.77</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">899774.62</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="24">
+          <autn:value_details>
+            <autn:values>24</autn:values>
+            <autn:valuesum>9855482.58</autn:valuesum>
+            <autn:valueaverate>410645.11</autn:valueaverate>
+            <autn:valuemin>66490.55</autn:valuemin>
+            <autn:valuemax>901928.61</autn:valuemax>
+            <autn:valuepercentile percentile="10">124675.94</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">195069.71</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">306486.74</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">580475.33</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">892760.11</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="23">
+          <autn:value_details>
+            <autn:values>23</autn:values>
+            <autn:valuesum>14759040.70</autn:valuesum>
+            <autn:valueaverate>641697.42</autn:valueaverate>
+            <autn:valuemin>84808.73</autn:valuemin>
+            <autn:valuemax>973970.89</autn:valuemax>
+            <autn:valuepercentile percentile="10">134695.76</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">360838.89</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">711878.61</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">920574.24</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">963339.74</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="22">
+          <autn:value_details>
+            <autn:values>22</autn:values>
+            <autn:valuesum>9802258.81</autn:valuesum>
+            <autn:valueaverate>445557.22</autn:valueaverate>
+            <autn:valuemin>11213.35</autn:valuemin>
+            <autn:valuemax>968761.61</autn:valuemax>
+            <autn:valuepercentile percentile="10">189022.04</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">267108.65</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">350804.04</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">617327.22</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">838072.94</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="6e+5,7e+5" type="range" count="97">
+        <autn:field value="CAT" count="28">
+          <autn:value_details>
+            <autn:values>28</autn:values>
+            <autn:valuesum>13911918.46</autn:valuesum>
+            <autn:valueaverate>496854.23</autn:valueaverate>
+            <autn:valuemin>26025.38</autn:valuemin>
+            <autn:valuemax>986441.06</autn:valuemax>
+            <autn:valuepercentile percentile="10">44634.46</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">118696.49</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">430173.64</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">806795.67</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">968275.59</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="20">
+          <autn:value_details>
+            <autn:values>20</autn:values>
+            <autn:valuesum>10591376.14</autn:valuesum>
+            <autn:valueaverate>529568.81</autn:valueaverate>
+            <autn:valuemin>6746.71</autn:valuemin>
+            <autn:valuemax>969381.55</autn:valuemax>
+            <autn:valuepercentile percentile="10">11519.32</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">248172.92</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">522094.72</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">851986.36</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">953333.77</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="20">
+          <autn:value_details>
+            <autn:values>20</autn:values>
+            <autn:valuesum>7635925.61</autn:valuesum>
+            <autn:valueaverate>381796.28</autn:valueaverate>
+            <autn:valuemin>17471.31</autn:valuemin>
+            <autn:valuemax>931736.91</autn:valuemax>
+            <autn:valuepercentile percentile="10">27514.97</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">79203.03</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">342287.74</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">548999.86</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">713587.95</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="29">
+          <autn:value_details>
+            <autn:values>29</autn:values>
+            <autn:valuesum>14081921.92</autn:valuesum>
+            <autn:valueaverate>485583.51</autn:valueaverate>
+            <autn:valuemin>78294.61</autn:valuemin>
+            <autn:valuemax>992573.76</autn:valuemax>
+            <autn:valuepercentile percentile="10">87808.25</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">346665.18</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">524002.44</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">632853.15</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">803182.01</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="7e+5,8e+5" type="range" count="103">
+        <autn:field value="CAT" count="30">
+          <autn:value_details>
+            <autn:values>30</autn:values>
+            <autn:valuesum>15921197.40</autn:valuesum>
+            <autn:valueaverate>530706.58</autn:valueaverate>
+            <autn:valuemin>15246.81</autn:valuemin>
+            <autn:valuemax>980326.16</autn:valuemax>
+            <autn:valuepercentile percentile="10">43423.52</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">335061.43</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">575420.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">772889.09</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">896197.44</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="28">
+          <autn:value_details>
+            <autn:values>28</autn:values>
+            <autn:valuesum>13435725.32</autn:valuesum>
+            <autn:valueaverate>479847.33</autn:valueaverate>
+            <autn:valuemin>13132.26</autn:valuemin>
+            <autn:valuemax>967138.48</autn:valuemax>
+            <autn:valuepercentile percentile="10">89563.02</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">209710.71</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">411192.96</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">659444.72</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">897406.95</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="15">
+          <autn:value_details>
+            <autn:values>15</autn:values>
+            <autn:valuesum>8703735.61</autn:valuesum>
+            <autn:valueaverate>580249.04</autn:valueaverate>
+            <autn:valuemin>26182.41</autn:valuemin>
+            <autn:valuemax>983363.66</autn:valuemax>
+            <autn:valuepercentile percentile="10">71818.05</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">382265.89</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">549749.87</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">882532.77</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">961256.38</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="30">
+          <autn:value_details>
+            <autn:values>30</autn:values>
+            <autn:valuesum>16871827.44</autn:valuesum>
+            <autn:valueaverate>562394.25</autn:valueaverate>
+            <autn:valuemin>4638.59</autn:valuemin>
+            <autn:valuemax>985434.14</autn:valuemax>
+            <autn:valuepercentile percentile="10">19722.42</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">362920.92</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">606763.86</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">777084.47</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">895479.42</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="8e+5,9e+5" type="range" count="103">
+        <autn:field value="CAT" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:valuesum>11921958.36</autn:valuesum>
+            <autn:valueaverate>458536.86</autn:valueaverate>
+            <autn:valuemin>4658.74</autn:valuemin>
+            <autn:valuemax>928906.35</autn:valuemax>
+            <autn:valuepercentile percentile="10">54441.21</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">182577.44</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">382455.56</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">736939.45</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">827555.16</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="29">
+          <autn:value_details>
+            <autn:values>29</autn:values>
+            <autn:valuesum>16425136.42</autn:valuesum>
+            <autn:valueaverate>566384.01</autn:valueaverate>
+            <autn:valuemin>15702.03</autn:valuemin>
+            <autn:valuemax>981534.36</autn:valuemax>
+            <autn:valuepercentile percentile="10">209843.47</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">479944.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">553542.85</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">724087.66</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">969764.22</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:valuesum>12887691.93</autn:valuesum>
+            <autn:valueaverate>495680.46</autn:valueaverate>
+            <autn:valuemin>11020.73</autn:valuemin>
+            <autn:valuemax>997277.79</autn:valuemax>
+            <autn:valuepercentile percentile="10">27718.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">236923.65</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">570975.39</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">663112.19</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">943790.25</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="22">
+          <autn:value_details>
+            <autn:values>22</autn:values>
+            <autn:valuesum>10897566.69</autn:valuesum>
+            <autn:valueaverate>495343.94</autn:valueaverate>
+            <autn:valuemin>2766.77</autn:valuemin>
+            <autn:valuemax>937498.88</autn:valuemax>
+            <autn:valuepercentile percentile="10">127045.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">301002.84</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">445165.25</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">685828.14</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">856689.31</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="9e+5,1e+6" type="range" count="103">
+        <autn:field value="CAT" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:valuesum>12808357.91</autn:valuesum>
+            <autn:valueaverate>492629.15</autn:valueaverate>
+            <autn:valuemin>171673.33</autn:valuemin>
+            <autn:valuemax>898630.99</autn:valuemax>
+            <autn:valuepercentile percentile="10">223520.34</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">308432.09</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">407223.11</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">719363.96</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">853490.65</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="28">
+          <autn:value_details>
+            <autn:values>28</autn:values>
+            <autn:valuesum>13956481.24</autn:valuesum>
+            <autn:valueaverate>498445.76</autn:valueaverate>
+            <autn:valuemin>5237.77</autn:valuemin>
+            <autn:valuemax>960174.82</autn:valuemax>
+            <autn:valuepercentile percentile="10">164118.13</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">229380.33</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">398900.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">792306.51</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">919611.54</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="18">
+          <autn:value_details>
+            <autn:values>18</autn:values>
+            <autn:valuesum>9539609.01</autn:valuesum>
+            <autn:valueaverate>529978.28</autn:valueaverate>
+            <autn:valuemin>45907.52</autn:valuemin>
+            <autn:valuemax>960616.68</autn:valuemax>
+            <autn:valuepercentile percentile="10">55899.52</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">263392.75</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">629519.24</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">782197.28</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">893747.85</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="31">
+          <autn:value_details>
+            <autn:values>31</autn:values>
+            <autn:valuesum>13331961.33</autn:valuesum>
+            <autn:valueaverate>430063.27</autn:valueaverate>
+            <autn:valuemin>6508.84</autn:valuemin>
+            <autn:valuemax>986660.28</autn:valuemax>
+            <autn:valuepercentile percentile="10">106952.01</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">174458.05</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">374104.35</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">615594.61</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">872294.27</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+    </autn:values>
+    <autn:engines>
+      <autn:used>0,1</autn:used>
+    </autn:engines>
+  </responsedata>
+</autnresponse>

--- a/src/test/resources/getQueryTagValuesFieldDependenceMultiLevelResponse.xml
+++ b/src/test/resources/getQueryTagValuesFieldDependenceMultiLevelResponse.xml
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<autnresponse xmlns:autn="http://schemas.autonomy.com/aci/">
+  <action>GETQUERYTAGVALUES</action>
+  <response>SUCCESS</response>
+  <responsedata>
+    <autn:number_of_fields>3</autn:number_of_fields>
+    <autn:field>
+      <autn:name>DOCUMENT/PRFIELD1</autn:name>
+      <autn:name>DOCUMENT/PET</autn:name>
+      <autn:name>DOCUMENT/PRFIELD2</autn:name>
+    </autn:field>
+    <autn:values>
+      <autn:field value="0,1e+5" type="range" count="1102">
+        <autn:field value="CAT" count="290">
+          <autn:value_details>
+            <autn:values>290</autn:values>
+            <autn:value_sum>15157447.30</autn:value_sum>
+            <autn:value_average>52267.06</autn:value_average>
+            <autn:value_min>1.78</autn:value_min>
+            <autn:value_max>986595.15</autn:value_max>
+            <autn:valuepercentile percentile="10">24925.21</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">55391.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">94480.02</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">130150.21</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">156221.18</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="271">
+          <autn:value_details>
+            <autn:values>271</autn:values>
+            <autn:value_sum>17421265.70</autn:value_sum>
+            <autn:value_average>64285.11</autn:value_average>
+            <autn:value_min>4.24</autn:value_min>
+            <autn:value_max>993074.96</autn:value_max>
+            <autn:valuepercentile percentile="10">26703.93</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">54868.39</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">103851.41</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">162844.03</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">198110.22</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="266">
+          <autn:value_details>
+            <autn:values>266</autn:values>
+            <autn:value_sum>10661085.53</autn:value_sum>
+            <autn:value_average>40079.27</autn:value_average>
+            <autn:value_min>1.09</autn:value_min>
+            <autn:value_max>994009.15</autn:value_max>
+            <autn:valuepercentile percentile="10">13993.89</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">30479.51</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">67142.07</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">114100.82</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">149891.65</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="275">
+          <autn:value_details>
+            <autn:values>275</autn:values>
+            <autn:value_sum>10815786.33</autn:value_sum>
+            <autn:value_average>39330.13</autn:value_average>
+            <autn:value_min>5.84</autn:value_min>
+            <autn:value_max>962168.64</autn:value_max>
+            <autn:valuepercentile percentile="10">21497.91</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">43271.01</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">75765.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">120212.92</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">144003.46</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="1e+5,2e+5" type="range" count="121">
+        <autn:field value="CAT" count="27">
+          <autn:value_details>
+            <autn:values>27</autn:values>
+            <autn:value_sum>12914500.57</autn:value_sum>
+            <autn:value_average>478314.84</autn:value_average>
+            <autn:value_min>27760.23</autn:value_min>
+            <autn:value_max>952893.61</autn:value_max>
+            <autn:valuepercentile percentile="10">96947.85</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">168644.01</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">485768.05</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">758187.16</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">892292.61</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:value_sum>11131200.08</autn:value_sum>
+            <autn:value_average>428123.08</autn:value_average>
+            <autn:value_min>21403.14</autn:value_min>
+            <autn:value_max>916414.7</autn:value_max>
+            <autn:valuepercentile percentile="10">41951.95</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">245419.76</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">396824.41</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">628484.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">871320.45</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="31">
+          <autn:value_details>
+            <autn:values>31</autn:values>
+            <autn:value_sum>15964484.77</autn:value_sum>
+            <autn:value_average>514983.38</autn:value_average>
+            <autn:value_min>32361.59</autn:value_min>
+            <autn:value_max>972633.87</autn:value_max>
+            <autn:valuepercentile percentile="10">100303.96</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">182650.71</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">522854.27</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">785529.41</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">931478.96</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="37">
+          <autn:value_details>
+            <autn:values>37</autn:values>
+            <autn:value_sum>23828900.09</autn:value_sum>
+            <autn:value_average>644024.33</autn:value_average>
+            <autn:value_min>100928.78</autn:value_min>
+            <autn:value_max>999435.61</autn:value_max>
+            <autn:valuepercentile percentile="10">183039.23</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">473874.88</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">738429.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">846788.91</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">949961.97</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="2e+5,3e+5" type="range" count="82">
+        <autn:field value="CAT" count="21">
+          <autn:value_details>
+            <autn:values>21</autn:values>
+            <autn:value_sum>10355440.17</autn:value_sum>
+            <autn:value_average>493116.21</autn:value_average>
+            <autn:value_min>71904.72</autn:value_min>
+            <autn:value_max>985728.53</autn:value_max>
+            <autn:valuepercentile percentile="10">182406.12</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">327229.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">417793.46</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">621053.43</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">940898.15</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="15">
+          <autn:value_details>
+            <autn:values>15</autn:values>
+            <autn:value_sum>5726845.69</autn:value_sum>
+            <autn:value_average>381789.71</autn:value_average>
+            <autn:value_min>17862.39</autn:value_min>
+            <autn:value_max>848123.44</autn:value_max>
+            <autn:valuepercentile percentile="10">48297.53</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">90678.82</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">347059.09</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">610836.84</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">816736.01</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="24">
+          <autn:value_details>
+            <autn:values>24</autn:values>
+            <autn:value_sum>10598218.56</autn:value_sum>
+            <autn:value_average>441592.44</autn:value_average>
+            <autn:value_min>3360.82</autn:value_min>
+            <autn:value_max>959114.81</autn:value_max>
+            <autn:valuepercentile percentile="10">43928.39</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">53428.43</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">451572.08</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">615189.18</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">933396.07</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="22">
+          <autn:value_details>
+            <autn:values>22</autn:values>
+            <autn:value_sum>12681844.24</autn:value_sum>
+            <autn:value_average>576447.47</autn:value_average>
+            <autn:value_min>12380.12</autn:value_min>
+            <autn:value_max>977385.83</autn:value_max>
+            <autn:valuepercentile percentile="10">168907.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">375303.97</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">591551.92</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">779934.76</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">935445.46</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="3e+5,4e+5" type="range" count="99">
+        <autn:field value="CAT" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:value_sum>12905427.78</autn:value_sum>
+            <autn:value_average>496362.61</autn:value_average>
+            <autn:value_min>21762.61</autn:value_min>
+            <autn:value_max>988473.93</autn:value_max>
+            <autn:valuepercentile percentile="10">123967.34</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">296510.87</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">458297.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">682620.14</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">906208.35</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="25">
+          <autn:value_details>
+            <autn:values>25</autn:values>
+            <autn:value_sum>12145665.57</autn:value_sum>
+            <autn:value_average>485826.62</autn:value_average>
+            <autn:value_min>59584.15</autn:value_min>
+            <autn:value_max>954265.69</autn:value_max>
+            <autn:valuepercentile percentile="10">142859.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">290900.87</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">473607.95</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">650082.08</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">940586.34</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="23">
+          <autn:value_details>
+            <autn:values>23</autn:values>
+            <autn:value_sum>11780720.50</autn:value_sum>
+            <autn:value_average>512205.24</autn:value_average>
+            <autn:value_min>2794.41</autn:value_min>
+            <autn:value_max>976535.01</autn:value_max>
+            <autn:valuepercentile percentile="10">106327.41</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">341133.51</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">471927.36</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">801728.64</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">903995.93</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="25">
+          <autn:value_details>
+            <autn:values>25</autn:values>
+            <autn:value_sum>13944669.29</autn:value_sum>
+            <autn:value_average>557786.77</autn:value_average>
+            <autn:value_min>31993.67</autn:value_min>
+            <autn:value_max>954235.22</autn:value_max>
+            <autn:valuepercentile percentile="10">255054.08</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">338133.18</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">620974.21</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">732722.49</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">915464.73</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="4e+5,5e+5" type="range" count="96">
+        <autn:field value="CAT" count="24">
+          <autn:value_details>
+            <autn:values>24</autn:values>
+            <autn:value_sum>9389638.44</autn:value_sum>
+            <autn:value_average>391234.93</autn:value_average>
+            <autn:value_min>7778.88</autn:value_min>
+            <autn:value_max>964179.01</autn:value_max>
+            <autn:valuepercentile percentile="10">60313.32</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">126145.57</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">287628.96</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">576440.02</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">769155.49</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="20">
+          <autn:value_details>
+            <autn:values>20</autn:values>
+            <autn:value_sum>10979013.24</autn:value_sum>
+            <autn:value_average>548950.66</autn:value_average>
+            <autn:value_min>8057.18</autn:value_min>
+            <autn:value_max>963585.23</autn:value_max>
+            <autn:valuepercentile percentile="10">74917.75</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">220605.58</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">538020.91</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">836265.98</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">908026.89</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="22">
+          <autn:value_details>
+            <autn:values>22</autn:values>
+            <autn:value_sum>9976724.22</autn:value_sum>
+            <autn:value_average>453487.46</autn:value_average>
+            <autn:value_min>999.12</autn:value_min>
+            <autn:value_max>871979.87</autn:value_max>
+            <autn:valuepercentile percentile="10">67741.54</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">264598.27</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">427789.18</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">656715.06</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">807782.35</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="30">
+          <autn:value_details>
+            <autn:values>30</autn:values>
+            <autn:value_sum>14673574.22</autn:value_sum>
+            <autn:value_average>489119.14</autn:value_average>
+            <autn:value_min>15105.01</autn:value_min>
+            <autn:value_max>973162.81</autn:value_max>
+            <autn:valuepercentile percentile="10">66019.25</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">222458.01</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">475668.89</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">732428.09</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">937055.34</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="5e+5,6e+5" type="range" count="94">
+        <autn:field value="CAT" count="25">
+          <autn:value_details>
+            <autn:values>25</autn:values>
+            <autn:value_sum>11339400.49</autn:value_sum>
+            <autn:value_average>453576.02</autn:value_average>
+            <autn:value_min>14703.35</autn:value_min>
+            <autn:value_max>935905.01</autn:value_max>
+            <autn:valuepercentile percentile="10">42205.39</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">109677.76</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">454038.06</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">710463.77</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">899774.62</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="24">
+          <autn:value_details>
+            <autn:values>24</autn:values>
+            <autn:value_sum>9855482.58</autn:value_sum>
+            <autn:value_average>410645.11</autn:value_average>
+            <autn:value_min>66490.55</autn:value_min>
+            <autn:value_max>901928.61</autn:value_max>
+            <autn:valuepercentile percentile="10">124675.94</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">195069.71</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">306486.74</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">580475.33</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">892760.11</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="23">
+          <autn:value_details>
+            <autn:values>23</autn:values>
+            <autn:value_sum>14759040.70</autn:value_sum>
+            <autn:value_average>641697.42</autn:value_average>
+            <autn:value_min>84808.73</autn:value_min>
+            <autn:value_max>973970.89</autn:value_max>
+            <autn:valuepercentile percentile="10">134695.76</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">360838.89</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">711878.61</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">920574.24</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">963339.74</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="22">
+          <autn:value_details>
+            <autn:values>22</autn:values>
+            <autn:value_sum>9802258.81</autn:value_sum>
+            <autn:value_average>445557.22</autn:value_average>
+            <autn:value_min>11213.35</autn:value_min>
+            <autn:value_max>968761.61</autn:value_max>
+            <autn:valuepercentile percentile="10">189022.04</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">267108.65</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">350804.04</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">617327.22</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">838072.94</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="6e+5,7e+5" type="range" count="97">
+        <autn:field value="CAT" count="28">
+          <autn:value_details>
+            <autn:values>28</autn:values>
+            <autn:value_sum>13911918.46</autn:value_sum>
+            <autn:value_average>496854.23</autn:value_average>
+            <autn:value_min>26025.38</autn:value_min>
+            <autn:value_max>986441.06</autn:value_max>
+            <autn:valuepercentile percentile="10">44634.46</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">118696.49</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">430173.64</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">806795.67</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">968275.59</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="20">
+          <autn:value_details>
+            <autn:values>20</autn:values>
+            <autn:value_sum>10591376.14</autn:value_sum>
+            <autn:value_average>529568.81</autn:value_average>
+            <autn:value_min>6746.71</autn:value_min>
+            <autn:value_max>969381.55</autn:value_max>
+            <autn:valuepercentile percentile="10">11519.32</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">248172.92</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">522094.72</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">851986.36</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">953333.77</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="20">
+          <autn:value_details>
+            <autn:values>20</autn:values>
+            <autn:value_sum>7635925.61</autn:value_sum>
+            <autn:value_average>381796.28</autn:value_average>
+            <autn:value_min>17471.31</autn:value_min>
+            <autn:value_max>931736.91</autn:value_max>
+            <autn:valuepercentile percentile="10">27514.97</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">79203.03</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">342287.74</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">548999.86</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">713587.95</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="29">
+          <autn:value_details>
+            <autn:values>29</autn:values>
+            <autn:value_sum>14081921.92</autn:value_sum>
+            <autn:value_average>485583.51</autn:value_average>
+            <autn:value_min>78294.61</autn:value_min>
+            <autn:value_max>992573.76</autn:value_max>
+            <autn:valuepercentile percentile="10">87808.25</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">346665.18</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">524002.44</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">632853.15</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">803182.01</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="7e+5,8e+5" type="range" count="103">
+        <autn:field value="CAT" count="30">
+          <autn:value_details>
+            <autn:values>30</autn:values>
+            <autn:value_sum>15921197.40</autn:value_sum>
+            <autn:value_average>530706.58</autn:value_average>
+            <autn:value_min>15246.81</autn:value_min>
+            <autn:value_max>980326.16</autn:value_max>
+            <autn:valuepercentile percentile="10">43423.52</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">335061.43</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">575420.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">772889.09</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">896197.44</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="28">
+          <autn:value_details>
+            <autn:values>28</autn:values>
+            <autn:value_sum>13435725.32</autn:value_sum>
+            <autn:value_average>479847.33</autn:value_average>
+            <autn:value_min>13132.26</autn:value_min>
+            <autn:value_max>967138.48</autn:value_max>
+            <autn:valuepercentile percentile="10">89563.02</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">209710.71</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">411192.96</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">659444.72</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">897406.95</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="15">
+          <autn:value_details>
+            <autn:values>15</autn:values>
+            <autn:value_sum>8703735.61</autn:value_sum>
+            <autn:value_average>580249.04</autn:value_average>
+            <autn:value_min>26182.41</autn:value_min>
+            <autn:value_max>983363.66</autn:value_max>
+            <autn:valuepercentile percentile="10">71818.05</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">382265.89</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">549749.87</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">882532.77</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">961256.38</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="30">
+          <autn:value_details>
+            <autn:values>30</autn:values>
+            <autn:value_sum>16871827.44</autn:value_sum>
+            <autn:value_average>562394.25</autn:value_average>
+            <autn:value_min>4638.59</autn:value_min>
+            <autn:value_max>985434.14</autn:value_max>
+            <autn:valuepercentile percentile="10">19722.42</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">362920.92</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">606763.86</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">777084.47</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">895479.42</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="8e+5,9e+5" type="range" count="103">
+        <autn:field value="CAT" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:value_sum>11921958.36</autn:value_sum>
+            <autn:value_average>458536.86</autn:value_average>
+            <autn:value_min>4658.74</autn:value_min>
+            <autn:value_max>928906.35</autn:value_max>
+            <autn:valuepercentile percentile="10">54441.21</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">182577.44</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">382455.56</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">736939.45</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">827555.16</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="29">
+          <autn:value_details>
+            <autn:values>29</autn:values>
+            <autn:value_sum>16425136.42</autn:value_sum>
+            <autn:value_average>566384.01</autn:value_average>
+            <autn:value_min>15702.03</autn:value_min>
+            <autn:value_max>981534.36</autn:value_max>
+            <autn:valuepercentile percentile="10">209843.47</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">479944.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">553542.85</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">724087.66</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">969764.22</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:value_sum>12887691.93</autn:value_sum>
+            <autn:value_average>495680.46</autn:value_average>
+            <autn:value_min>11020.73</autn:value_min>
+            <autn:value_max>997277.79</autn:value_max>
+            <autn:valuepercentile percentile="10">27718.29</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">236923.65</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">570975.39</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">663112.19</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">943790.25</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="22">
+          <autn:value_details>
+            <autn:values>22</autn:values>
+            <autn:value_sum>10897566.69</autn:value_sum>
+            <autn:value_average>495343.94</autn:value_average>
+            <autn:value_min>2766.77</autn:value_min>
+            <autn:value_max>937498.88</autn:value_max>
+            <autn:valuepercentile percentile="10">127045.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">301002.84</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">445165.25</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">685828.14</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">856689.31</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+      <autn:field value="9e+5,1e+6" type="range" count="103">
+        <autn:field value="CAT" count="26">
+          <autn:value_details>
+            <autn:values>26</autn:values>
+            <autn:value_sum>12808357.91</autn:value_sum>
+            <autn:value_average>492629.15</autn:value_average>
+            <autn:value_min>171673.33</autn:value_min>
+            <autn:value_max>898630.99</autn:value_max>
+            <autn:valuepercentile percentile="10">223520.34</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">308432.09</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">407223.11</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">719363.96</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">853490.65</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="DOG" count="28">
+          <autn:value_details>
+            <autn:values>28</autn:values>
+            <autn:value_sum>13956481.24</autn:value_sum>
+            <autn:value_average>498445.76</autn:value_average>
+            <autn:value_min>5237.77</autn:value_min>
+            <autn:value_max>960174.82</autn:value_max>
+            <autn:valuepercentile percentile="10">164118.13</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">229380.33</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">398900.31</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">792306.51</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">919611.54</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="FISH" count="18">
+          <autn:value_details>
+            <autn:values>18</autn:values>
+            <autn:value_sum>9539609.01</autn:value_sum>
+            <autn:value_average>529978.28</autn:value_average>
+            <autn:value_min>45907.52</autn:value_min>
+            <autn:value_max>960616.68</autn:value_max>
+            <autn:valuepercentile percentile="10">55899.52</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">263392.75</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">629519.24</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">782197.28</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">893747.85</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+        <autn:field value="PIG" count="31">
+          <autn:value_details>
+            <autn:values>31</autn:values>
+            <autn:value_sum>13331961.33</autn:value_sum>
+            <autn:value_average>430063.27</autn:value_average>
+            <autn:value_min>6508.84</autn:value_min>
+            <autn:value_max>986660.28</autn:value_max>
+            <autn:valuepercentile percentile="10">106952.01</autn:valuepercentile>
+            <autn:valuepercentile percentile="25">174458.05</autn:valuepercentile>
+            <autn:valuepercentile percentile="50">374104.35</autn:valuepercentile>
+            <autn:valuepercentile percentile="75">615594.61</autn:valuepercentile>
+            <autn:valuepercentile percentile="90">872294.27</autn:valuepercentile>
+          </autn:value_details>
+        </autn:field>
+      </autn:field>
+    </autn:values>
+    <autn:engines>
+      <autn:used>0,1</autn:used>
+    </autn:engines>
+  </responsedata>
+</autnresponse>


### PR DESCRIPTION
FieldDependenceMultiLevel response could return either <autn:value_sum> or <autn:valuesum> etc.
Ensure both handled equally.
Technically calling setValueMax will result in both tags being printed if serialized to XML, but that shouldn't cause any problems.